### PR TITLE
Fixed Async Race Condition when Displaying Tooltip

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,20 +53,15 @@ document.addEventListener('mouseover', function(event) {
     });
 }
   else if (event.target.classList.contains('GeyserLabel')) {
-    var circleId = event.target.id.replace(' Geyser Label', '');
-    getLink(circleId)
-    .then(result => {
-      LastEruption(circleId, result);
-      setTimeout(() =>{
-          console.log('1');
-          resolve();
-      }, 1000);
-    })
-    .then(() => {
-      console.log('2')
-        ToggleVisibility();
-    });
-}
+      var circleId = event.target.id.replace(' Geyser Label', '');
+      new Promise(function(resolve) {
+          resolve(getLink(circleId))
+      }).then(function(result) {
+          return LastEruption(circleId, result)
+      }).then(function() {
+          ToggleVisibility();
+      })
+  }
 });
 
 //Generate link to request geyser info through API
@@ -92,37 +87,33 @@ function getPredictionLink(circleID){
   });
 };
 //Fetching and printing last geyser eruption
-function LastEruption(circleID, link){
-  fetch(link)
-    .then(res => res.json())
-    .then(data => {
-      const entry = data.entries[0];
-      const eruptionTime = entry.time;
-      const date = new Date(eruptionTime * 1000);
-      const timeFormatting = {
-        month: 'short', 
-        day: 'numeric',     
-        year: 'numeric',     
-        hour: '2-digit',     
-        minute: '2-digit',   
-        timeZoneName: 'short',  
-        hour12: true  
-      };
-      // Convert the date to a string in the specified time zone
-      const formattedDate = date.toLocaleString('en-US', timeFormatting);
-      const targetDiv = document.getElementById('PredictableText');
-      const targetHeader = targetDiv.querySelector('H3');
-      targetHeader.innerHTML = `${circleID} Geyser`;
-      const targetParagraph = targetDiv.querySelector('p');
-      targetParagraph.innerHTML = `Last eruption: ${formattedDate}`;
-      const target = document.getElementById('PredictableText');
-      const targetP = target.querySelector('#Prediction');
-      targetP.innerHTML = ``;
-    })
-    .catch(error => {
-      console.error('Error fetching data:', error);
-    });
-  };
+async function LastEruption(circleID, link){
+    const response = await fetch(link)
+    const jsonResp = await response.json()
+
+    const entry = jsonResp.entries[0];
+    const eruptionTime = entry.time;
+    const date = new Date(eruptionTime * 1000);
+    const timeFormatting = {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZoneName: 'short',
+        hour12: true
+    };
+    // Convert the date to a string in the specified time zone
+    const formattedDate = date.toLocaleString('en-US', timeFormatting);
+    const targetDiv = document.getElementById('PredictableText');
+    const targetHeader = targetDiv.querySelector('H3');
+    targetHeader.innerHTML = `${circleID} Geyser`;
+    const targetParagraph = targetDiv.querySelector('p');
+    targetParagraph.innerHTML = `Last eruption: ${formattedDate}`;
+    const target = document.getElementById('PredictableText');
+    const targetP = target.querySelector('#Prediction');
+    targetP.innerHTML = ``;
+};
 
   function PredictionEruption(link){
     fetch(link)


### PR DESCRIPTION
**Description**
----------------------------
![image](https://github.com/vkarshina/Geyser/assets/26468685/0eb0e47d-891a-4231-8ead-2bd214b4bd9b)
It looked like the asynchronous fetches in the LastEruption function were causing the text to be updated after the tooltip's visibility was toggled. 

![image](https://github.com/vkarshina/Geyser/assets/26468685/f9e5adf5-d344-451e-a29e-530af2768f3d)
Changed the .then()'s to await's in the LastEruption function.

![image](https://github.com/vkarshina/Geyser/assets/26468685/d737b70a-c6e1-49e0-af88-56a91a5b9ee3)
 That way, we can define LastEruption as an async function and force functions to wait for it to complete in the promise chain.